### PR TITLE
Update to Twitter API v1.1 endpoint.

### DIFF
--- a/planetwit.lisp
+++ b/planetwit.lisp
@@ -49,7 +49,7 @@
 (alexandria:when-let (file (probe-file "access-token.lisp"))
   (load file))
 
-(defparameter *twitter-url* "https://api.twitter.com/1/statuses/update.xml")
+(defparameter *twitter-url* "https://api.twitter.com/1.1/statuses/update.json")
 
 (defun post-to-twitter (item)
   (format t "post-to-twitter: ~S~%" item)


### PR DESCRIPTION
It seems this will suffice.

Tested with: 

``` lisp
PLANETWIT> (post-to-twitter (list :guid "Testing API v1.1"
                  :title "It WORKS!"))
post-to-twitter: (:GUID "Testing API v1.1" :TITLE "It WORKS!")
posting "It WORKS! Testing API v1.1"
NIL
```

https://twitter.com/jsmp_api/status/347861102157238272
